### PR TITLE
Add webhook script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Qiklife Web App
+
+This project is a React application built with Vite and Tailwind CSS. It provides a dashboard-style interface and includes a custom visual editor for inline editing.
+
+## Prerequisites
+
+- Node.js v18 or later
+- npm (comes with Node.js)
+
+## Getting Started
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+   The app will be available at `http://localhost:5173` by default.
+
+3. Build for production:
+
+   ```bash
+  npm run build
+  ```
+
+4. Preview the production build locally:
+
+   ```bash
+  npm run preview
+  ```
+
+5. Send a test payload to the webhook:
+   ```bash
+   npm run send-webhook
+   ```
+
+## Project Structure
+
+- `src/` – Application source code
+- `plugins/` – Custom Vite plugins used for the visual editor
+- `tools/` – Helper scripts (e.g., `generate-llms.js` to create `public/llms.txt`, `send-webhook.js` to send a webhook payload)
+
+## Notes
+
+During development, the visual editor plugins automatically inject scripts for error monitoring and fetch interception. These are enabled when `NODE_ENV` is not `production`.

--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
 	"type": "module",
 	"version": "0.0.0",
 	"private": true,
-	"scripts": {
-		"dev": "vite",
-		"build": "node tools/generate-llms.js || true && vite build",
-		"preview": "vite preview"
-	},
+        "scripts": {
+                "dev": "vite",
+                "build": "node tools/generate-llms.js || true && vite build",
+                "preview": "vite preview",
+                "send-webhook": "node tools/send-webhook.js"
+        },
 	"dependencies": {
 		"@radix-ui/react-alert-dialog": "^1.0.5",
 		"@radix-ui/react-avatar": "^1.0.3",

--- a/tools/send-webhook.js
+++ b/tools/send-webhook.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const webhookUrl = 'https://thodar.click/webhook/c404a8f7-a4bf-4574-9bac-2df4887b7063';
+
+async function main() {
+  const payload = { message: 'Hello from Qiklife' };
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    console.log(`Response status: ${res.status}`);
+    const text = await res.text();
+    console.log('Response body:', text);
+  } catch (err) {
+    console.error('Request failed:', err.message);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add script to send data to remote webhook
- document how to use the webhook script

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685def71137c833182203c0c74e92bce